### PR TITLE
Fix SearchRequest.Type being ignored

### DIFF
--- a/src/BoardGamer.BoardGameGeek/BoardGameGeekXmlApi2/SearchRequest.cs
+++ b/src/BoardGamer.BoardGameGeek/BoardGameGeekXmlApi2/SearchRequest.cs
@@ -16,7 +16,7 @@ namespace BoardGamer.BoardGameGeek.BoardGameGeekXmlApi2
             bool? exact = null)
         {
             Query = query;
-            Type = null;
+            Type = type;
             Exact = exact;
             RelativeUrl = BuildRelativeUrl();
         }


### PR DESCRIPTION
Thanks for building and sharing this library! I noticed SearchRequest.Type wasn't filtering the results, and I think this might be the problem. Hope it's an easy pull!