### PR TITLE
Fix parsing of double to account for decimal point

### DIFF
--- a/src/BoardGamer.BoardGameGeek/Extensions.cs
+++ b/src/BoardGamer.BoardGameGeek/Extensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -54,12 +55,12 @@ namespace BoardGamer.BoardGameGeek
 
         public static double AttributeValueAsDouble(this XElement element, string attributeName = "value")
         {
-            return Double.TryParse(element.AttributeValue(attributeName), out double v) ? v : default(double);
+            return Double.TryParse(element.AttributeValue(attributeName), NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out double v) ? v : default(double);
         }
 
         public static double? AttributeValueAsNullableDouble(this XElement element, string attributeName = "value")
         {
-            return Double.TryParse(element.AttributeValue(attributeName), out double v) ? v : (double?)null;
+            return Double.TryParse(element.AttributeValue(attributeName), NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out double v) ? v : (double?)null;
         }
 
         public static int AttributeValueAsInt32(this XElement element, string attributeName = "value")


### PR DESCRIPTION
Parsing of double type in ThingResponse does not account for decimal points in BGG XML-API

>A rating of "3.324" becomes "3324"

To fix this, I added the option to allow decimal points and use "InvariantCulture"

