### PR TITLE
StatusCode is missing in HttpRequestException

### DIFF
--- a/src/BoardGamer.BoardGameGeek/BoardGameGeekXmlApi2/BoardGameGeekHttpException.cs
+++ b/src/BoardGamer.BoardGameGeek/BoardGameGeekXmlApi2/BoardGameGeekHttpException.cs
@@ -1,0 +1,16 @@
+using System.Net;
+using System.Net.Http;
+
+namespace BoardGamer.BoardGameGeek.BoardGameGeekXmlApi2
+{
+    public class BoardGameGeekHttpException : HttpRequestException
+    {
+        public HttpStatusCode StatusCode { get; }
+
+        public BoardGameGeekHttpException(string message, HttpStatusCode statusCode)
+            : base(message)
+        {
+            StatusCode = statusCode;
+        }
+    }
+}

--- a/src/BoardGamer.BoardGameGeek/BoardGameGeekXmlApi2/BoardGameGeekXmlApi2Client.cs
+++ b/src/BoardGamer.BoardGameGeek/BoardGameGeekXmlApi2/BoardGameGeekXmlApi2Client.cs
@@ -1002,10 +1002,10 @@ namespace BoardGamer.BoardGameGeek.BoardGameGeekXmlApi2
                 {
                     if (httpResponse.StatusCode == HttpStatusCode.Unauthorized)
                     {
-                        throw new HttpRequestException($"The boardgamegeek xml api requires an authorization token is for access. See https://boardgamegeek.com/using_the_xml_api StatusCode = {httpResponse.StatusCode}");
+                        throw new BoardGameGeekHttpException($"The boardgamegeek xml api requires an authorization token is for access. See https://boardgamegeek.com/using_the_xml_api StatusCode = {httpResponse.StatusCode}", httpResponse.StatusCode);
                     }
 
-                    throw new HttpRequestException($"The boardgamegeek xml api request failed. StatusCode = {httpResponse.StatusCode}");
+                    throw new BoardGameGeekHttpException($"The boardgamegeek xml api request failed. StatusCode = {httpResponse.StatusCode}", httpResponse.StatusCode);
                 }
 
                 if (httpResponse.StatusCode == System.Net.HttpStatusCode.Accepted)


### PR DESCRIPTION
Hi,

Thanks for the nice library! I'm using it in a small project of mine and found something that I was hoping to improve.

## Info
I created this PR because I was using your library and noticed that when BGG returns a not successfull state (Unauthorized, ...) I currently can only tell the difference by parsing the exception message (status code is in there). So I tried to clean it up a bit and now the StatusCode of the call is reported in the thrown exception. 

Now you will return a custom BoardGameGeekHttpException that holds the proper status code. Meaning, no more string checks or regex to really know the failed status code.

One limitation here, because the project is still on netstandard2.0 there is no status code yet on HttpRequestException that's why I created BoardGameGeekHttpException which inherrits from HttpRequestException. If you are able and willing to move to at least .NET6.0 you don't need the custom BoardGameGeekHttpException anymore.

## Screenshot
This is how an exception looks like after the change
<img width="1292" height="707" alt="image" src="https://github.com/user-attachments/assets/09d8e704-cdd5-40bf-b2f3-5997b663741c" />

Let me know if you like the PR or you wanted something changed.